### PR TITLE
Allow for Environment variable to adjust requests timeout

### DIFF
--- a/zenoss_client.py
+++ b/zenoss_client.py
@@ -135,6 +135,8 @@ class ZenossAction(object):
         Return callable method
         """
         def wrapped(timeout=None, **kwargs):
+            if os.environ['zenossTimeOut']:
+                timeout = int(os.environ['zenossTimeOut'])
             payload = {'action': self.action, 'method': method,
                     'tid': self.session.tid, 'data': [kwargs]}
             result = self.session.post(


### PR DESCRIPTION
Allows for zenossTimeOut to be set as environment variable for when Zenoss API does not respond in a timely manner.